### PR TITLE
Add configuration for Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
     branches:
-      - main
+      - master
   schedule:
     - cron: '23 1 * * 0'
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '23 1 * * 0'
+  workflow_dispatch:
+
+jobs:
+  testing:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade .[test]
+
+      - name: Run tests
+        run: tox
+
+  finalise:
+    runs-on: ubuntu-latest
+    needs: [testing]
+    steps:
+      - name: finalise
+        run: echo "All done"


### PR DESCRIPTION
The CI was configured to use Gitlab's runners. Contributions on Github would therefore only be tested once changes were uploaded to ASTRON's git server. This PR adds a configuration for Github Actions such that the test suite is run whenever any of the following happens:
* A commit is pushed to a branch
* A PR is created for the `master` branch
* It is 1:23 UTC on a Sunday (this is an automatic weekly test)
