### PR TITLE
Apply delay fullms

### DIFF
--- a/steps/applycal.cwl
+++ b/steps/applycal.cwl
@@ -8,7 +8,7 @@ baseCommand:
 
 inputs:
     - id: ms
-      type: Directory[]
+      type: Directory
       doc: Input MeasurementSet
       inputBinding:
         position: 5
@@ -25,7 +25,7 @@ inputs:
 
 outputs:
     - id: ms_out
-      type: Directory[]
+      type: Directory
       doc: Output MeasurementSet with solutions applied
       outputBinding:
         glob: "applied_*"

--- a/steps/applycal.cwl
+++ b/steps/applycal.cwl
@@ -8,7 +8,7 @@ baseCommand:
 
 inputs:
     - id: ms
-      type: Directory
+      type: Directory[]
       doc: Input MeasurementSet
       inputBinding:
         position: 5
@@ -25,7 +25,7 @@ inputs:
 
 outputs:
     - id: ms_out
-      type: Directory
+      type: Directory[]
       doc: Output MeasurementSet with solutions applied
       outputBinding:
         glob: "applied_*"

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -129,9 +129,6 @@ inputs:
       type: File?
       doc: Image to generate an initial delay calibration model from.
 
-    - id: lofar_helpers
-      type: Directory
-      doc: The LOFAR helpers directory.
 
 steps:
     - id: setup
@@ -253,7 +250,7 @@ steps:
           source:
             - phaseup/solutions
         - id: lofar_helpers
-          source: lofar_helpers
+          source: h5merger
       out:
         - id: ms_out
         - id: logfile

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -312,7 +312,7 @@ outputs:
     outputSource:
       - apply_delay_allms/ms_out
     pickValue: all_non_null
-    type: Directory[]?
+    type: Directory[]
     doc: |
         The concatenated data in MeasurementSet format after
         A-team clipping, optional DDF solutions applied, and 

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -128,6 +128,10 @@ inputs:
       type: File?
       doc: Image to generate an initial delay calibration model from.
 
+    - id: lofar_helpers
+      type: Directory
+      doc: The LOFAR helpers directory.
+
 steps:
     - id: setup
       label: setup
@@ -236,6 +240,24 @@ steps:
       run: ./phaseup-concat.cwl
       label: phaseup
 
+    - id: apply_delay_allms
+      in: 
+        - id: ms
+          source:
+            - process_ddf/msout
+            - sort-concatenate-flag/msout
+            - msin
+        - id: h5parm
+          source:
+            - phaseup/solutions
+        - id: lofar_helpers
+          source: lofar_helpers
+      out:
+        - ms_out
+        - logfile
+      run: ../steps/applycal.cwl
+      label: apply_delay_allms
+
     - id: store_logs
       in:
         - id: files
@@ -285,6 +307,16 @@ outputs:
     doc: |
         The concatenated data in MeasurementSet format after
         A-team clipping and optional DDF solutions applied.
+
+  - id: msouts_apply_delay
+    outputSource:
+      - apply_delay_allms/output
+    pickValue: all_non_null
+    type: Directory[]?
+    doc: |
+        The concatenated data in MeasurementSet format after
+        A-team clipping, optional DDF solutions applied, and 
+        delay solutions applied.
 
   - id: logs
     outputSource: store_logs/dir

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -22,6 +22,7 @@ requirements:
   - class: MultipleInputFeatureRequirement
   - class: StepInputExpressionRequirement
   - class: InlineJavascriptRequirement
+  - class: ScatterFeatureRequirement
 
 inputs:
     - id: msin

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -253,8 +253,8 @@ steps:
         - id: lofar_helpers
           source: lofar_helpers
       out:
-        - ms_out
-        - logfile
+        - id: ms_out
+        - id: logfile
       run: ../steps/applycal.cwl
       label: apply_delay_allms
 
@@ -310,7 +310,7 @@ outputs:
 
   - id: msouts_apply_delay
     outputSource:
-      - apply_delay_allms/output
+      - apply_delay_allms/ms_out
     pickValue: all_non_null
     type: Directory[]?
     doc: |

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -247,6 +247,7 @@ steps:
             - process_ddf/msout
             - sort-concatenate-flag/msout
             - msin
+          pickValue: first_non_null
         - id: h5parm
           source:
             - phaseup/solutions

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -257,6 +257,7 @@ steps:
         - id: ms_out
         - id: logfile
       run: ../steps/applycal.cwl
+      scatter: ms
       label: apply_delay_allms
 
     - id: store_logs


### PR DESCRIPTION
Add workflow step after phaseup, to apply facetselfcal solutions to full input MS and save to results directory. This is an additional step to apply direction-independent solutions to LINC-calibrated data.