### PR TITLE
Add differrent applycal opions for RM corrections

### DIFF
--- a/steps/dp3_make_parset.cwl
+++ b/steps/dp3_make_parset.cwl
@@ -30,6 +30,17 @@ inputs:
     default: TGSSphase
     doc: The type of correction to perform.
 
+  - id: rm_correction
+    type:
+      type: enum
+      symbols:
+        - "RMextract"
+        - "spinifex"
+    default: "spinifex"
+    doc: |
+      The name of the target solution table to use from the solset input for
+      rotation measure corrections.
+
 stdout: dp3.parset
 outputs:
   - id: parset
@@ -86,7 +97,7 @@ requirements:
           applybeam.updateweights             =   true
           #
           applyRM.type                        =   applycal
-          applyRM.correction                  =   RMextract
+          applyRM.correction                  =   $(inputs.rm_correction)
           applyRM.solset                      =   target
           #
           applyphase.type                     =   applycal

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -128,6 +128,17 @@ inputs:
       default: true
       doc: When set to true, the delay calibration solutions will be applied on the full MS.
 
+    - id: rm_correction
+      type:
+        type: enum
+        symbols:
+          - "RMextract"
+          - "spinifex"
+      default: "spinifex"
+      doc: |
+        The name of the target solution table to use from the solset input for
+        rotation measure corrections.
+
 steps:
     - id: setup
       label: setup
@@ -147,6 +158,8 @@ steps:
           source: number_cores
         - id: Ateam_skymodel
           source: Ateam_skymodel
+        - id: rm_correction
+          source: rm_correction
       out:
         - id: logdir
         - id: msout

--- a/workflows/setup.cwl
+++ b/workflows/setup.cwl
@@ -77,6 +77,17 @@ inputs:
       type: File
       doc: The skymodel to use in clipping bright sources.
 
+    - id: rm_correction
+      type:
+        type: enum
+        symbols:
+          - "RMextract"
+          - "spinifex"
+      default: "spinifex"
+      doc: |
+        The name of the target solution table to use from the solset input for
+        rotation measure corrections.
+
 requirements:
     - class: SubworkflowFeatureRequirement
     - class: MultipleInputFeatureRequirement
@@ -123,6 +134,8 @@ steps:
           source: solset
         - id: phasesol
           source: phasesol
+        - id: rm_correction
+          source: rm_correction
       out:
         - id: parset
       run: ../steps/dp3_make_parset.cwl


### PR DESCRIPTION
LINC has added support for `spinifex` in determining the rotation measure. LINC target solsets will therefore no longer include an RMextract table, but instead a spinifex one.

This is relevant for the A-team clipping workflow, where corrections from this table are applied to the data in dp3_prep_target.cwl before clipping. Here I allow for the possibility for the user to specify which table must be used by adding an `rm_correction` input to the delay-calibration and setup workflows and the step dp3_make_parset. This input specifies the table in LINC's solset that is to be used, similar to the phase corrections in `phasesol`.

For now it is enforced that the input is either `"RMextract"` or `"spinifex"`. The default value if `rm_correction` is not specified by the user is `"spinifex"`.

Resolves #8.