### PR TITLE
Remove duplicate entry in phaseup-concat log collection

### DIFF
--- a/workflows/phaseup-concat.cwl
+++ b/workflows/phaseup-concat.cwl
@@ -212,7 +212,6 @@ steps:
         linkMerge: merge_flattened
         source:
           - prep_delay/logfile
-          - concat_logfiles_phaseup/output
           - sort_concatenate/logfile
           - concat_logfiles_phaseup/output
           - delay_cal_model/logfile


### PR DESCRIPTION
The log collection step tried to collect logs from `concat_logfiles_phaseup/output` twice, leading to an error upon execution:

```
File "/cosma/apps/do011/dc-swei1/pyenv312/lib/python3.12/site-packages/toil/cwl/cwltoil.py", line 260, in ensure_no_collisions                                                      
            raise cwl_utils.errors.WorkflowException(                                                                                                                                         
        cwl_utils.errors.WorkflowException: File staging conflict: Duplicate entries for "dp3_phaseup.log" prevent actually creating the job's working directory as specified by the InitialWorkDirRequirement
```

This MR removes the duplicate input to the log collection step.