### PR TITLE
Make configfile in split-directions optional

### DIFF
--- a/workflows/split-directions.cwl
+++ b/workflows/split-directions.cwl
@@ -60,8 +60,7 @@ inputs:
       default: 0.0
       doc: Peak flux (Jy/beam) cut to pre-select sources from catalogue. Default at 0.0 is no peak flux selection.
     - id: configfile
-      type: File
-      default: null
+      type: File?
       doc: The configuration file to be used to run facetselfcal.py during the target_selfcal step.
 
 steps:


### PR DESCRIPTION
The `configfile` input in split directions is supposed to be optional, but if no input is provided it will search for a file called `"null"`. This doesn't exist, so the workflow will fail.

This patch fixes this by removing the default value and making the input itself optional.