### PR TITLE
Merge skymodel arrays flattened such that scatter works correctly

### DIFF
--- a/workflows/subworkflows/find-best-delay-calibrator.cwl
+++ b/workflows/subworkflows/find-best-delay-calibrator.cwl
@@ -91,6 +91,7 @@ steps:
             - starting_skymodel
             - generate_skymodels/skymodel
           pickValue: all_non_null
+          linkMerge: merge_flattened
       out:
         - id: sorted_entries
       run: ../../steps/sort_by_name.cwl


### PR DESCRIPTION
This fixes an issue in the recently added delay calibrator selection of `find-best-delay-calibrator.cwl`. The `sort_skymodels` step had two possible inputs, which ended up being an array with as entry an array, causing the scatter over MS-skymodel pairs to fail later on.