### PR TITLE
Remove unused ret import

### DIFF
--- a/scripts/make_config_dical.py
+++ b/scripts/make_config_dical.py
@@ -6,7 +6,6 @@ __author__ = "Jurjen de Jong, James Petley, Leah Morabito"
 from argparse import ArgumentParser
 from collections.abc import Sequence
 import os
-import ret
 
 from astropy.table import Table
 from astropy.coordinates import SkyCoord


### PR DESCRIPTION
In `scripts/make_config_dical.py` a module `ret` is imported, but never used. This could be either the third-party `ret` package (in which case it causes a crash if not installed) or mistyped `re` module form the Standard Library, but neither is used in this script so I think it's better to just remove it.
