### PR TITLE
Rename VLBI-cwl to PILOT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
-name = "VLBI-cwl"
+name = "PILOT"
+description = "PILOT: the VLBI Pipeline for the International LOFAR Telescope"
 version = "0.8.0"
 dependencies = [
     "astropy",


### PR DESCRIPTION
Whilst we have updated the README, the project name in pyproject.toml still mentions VLBI-cwl. This can create confusion.