### PR TITLE
Exit catalogue processing early for DI config if empty

### DIFF
--- a/scripts/make_config_dical.py
+++ b/scripts/make_config_dical.py
@@ -189,6 +189,9 @@ def process_catalog(imagecat, ms):
 
     bandpass = False # Default option
     phaseup = True # Default option
+
+    if not im_t:
+        return bandpass, phaseup
     
     with ct.table(f"{ms}/FIELD", readonly=True, ack=False) as field_table:
         phase_dir = field_table.getcol('PHASE_DIR')[0, 0]  # shape: (n_fields, 1, 2)


### PR DESCRIPTION
During the creation of delay calibration settings checks for an extra bandpass solve and phaseup are performed. This function relies on a catalogue that is passed along having entries. For fields without LoTSS coverage, for example, this catalogue will be empty, causing a crash.

This PR makes it such that the default values are returned instead in that scenario.

Fixes #56