### PR TITLE
Fix variable case for DI solution inspection

### DIFF
--- a/scripts/inspect_di_validated_sols.py
+++ b/scripts/inspect_di_validated_sols.py
@@ -26,6 +26,9 @@ def parse_args():
 def main():
     args = parse_args()
     validation_csv = pd.read_csv(args.validation_solutions_csv)
+    # Apparently we can encounter both Source_id and source_id for some reason
+    # so we homogenise case here.
+    validation_csv.columns = validation_csv.columns.str.lower()
 
     # Return an error if there are sources with bad solutions
     if args.return_error and sum(~validation_csv['accept_solutions'])>0:


### PR DESCRIPTION
Fixes #57

The inspection script looked for `Source_id` while the score catalogue was written with `source_id`. This changes the case in the script to look for the latter instead, after which the step runs for me.