### PR TITLE
Exclude skymodel solve when globbing for solutions

### DIFF
--- a/steps/facet_selfcal.cwl
+++ b/steps/facet_selfcal.cwl
@@ -47,7 +47,7 @@ outputs:
     - id: h5parm
       type: File
       outputBinding:
-        glob: [merged*.h5, merged_addCS*.h5]
+        glob: [merged_selfcalcycle*.h5, merged_addCS_selfcalcycle*.h5]
         outputEval: $(self[self.length - 1])
       doc: |
         The calibration solution files generated


### PR DESCRIPTION
It was found in #54 that the wrong h5parm could be returned from the delay calibration workflow at times. This also impacted the h5parm that would be passed to the validation.

This PR makes the globbing pattern a bit more specific, such that the solutions from the initial skymodel solve of the pattern `merged_sky*` are ignored and only h5parms from the selfcal iterations are considered.

Fixes #54 