### PR TITLE
Remove InplaceUpdateRequirement for ddf DI applycal

### DIFF
--- a/steps/dp3_applycal_ddf.cwl
+++ b/steps/dp3_applycal_ddf.cwl
@@ -100,8 +100,6 @@ requirements:
     listing:
       - entry: $(inputs.msin)
         writable: true
-  - class: InplaceUpdateRequirement
-    inplaceUpdate: true
   - class: ResourceRequirement
     coresMax: $(inputs.max_dp3_threads)
     coresMin: $(inputs.max_dp3_threads)


### PR DESCRIPTION
This PR removes the `InplaceUpdateRequirement` for the step that applies the DIS2 solutions to the data to stop the pipeline from modifying the original input data. This is safer in the grand scheme as corrupting the input data from an arbitrary crash would require LINC to be rerun in order to obtain the dataset.

Fixes #77