### PR TITLE
Give facetselfcal 60 GB of memory

### DIFF
--- a/steps/facet_selfcal.cwl
+++ b/steps/facet_selfcal.cwl
@@ -81,6 +81,7 @@ requirements:
       - entry: $(inputs.msin)
   - class: ResourceRequirement
     coresMin: $(inputs.number_cores)
+    ramMin: 60000
 
 hints:
   - class: DockerRequirement


### PR DESCRIPTION
This PR updates the facetselfcal call for the delay calibration based on the information from Toil collected in the profiling repository at https://github.com/LOFAR-VLBI/profiling:
```
Job CWLJob delay_cal_run.delay_solve.facet_selfcal used >8GB RAM -- 45.56 GB used
```
This was the only job using more than 8 GB of RAM according to Toil. With this the delay calibration workflow without LoTSS subtraction (which will be covered by [slurm-resources-subtraction](https://github.com/LOFAR-VLBI/pilot/tree/slurm-resources-subtraction) ) should be functional again on memory-enforcing clusters like cosma. The usage is set to 60 GB to not be too strict and give it some breathing room.