### PR TITLE
Use the_only_non_null method for single element arrays

### DIFF
--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -214,7 +214,7 @@ steps:
         - id: msin
           source:
            - setup/msout
-          pickValue: all_non_null
+          pickValue: the_only_non_null
         - id: firstSB
           source: reference_stationSB
         - id: max_dp3_threads
@@ -453,7 +453,7 @@ outputs:
     outputSource: 
       - phaseup/facetselfcal_config
     type: File
-    pickValue: all_non_null
+    pickValue: the_only_non_null
     doc: Config file with settings used for the delay calibration.
 
   - id: facetselfcal_starting_model
@@ -488,7 +488,7 @@ outputs:
       - select_best_delay_cal/phasediff_score_csv
     type:
       - File?
-    pickValue: all_non_null
+    pickValue: the_only_non_null
     doc: |
         A CSV file containing the phasediff scores for each of the calibrators that were split out.
 

--- a/workflows/process-ddf.cwl
+++ b/workflows/process-ddf.cwl
@@ -51,7 +51,7 @@ outputs:
     type: File?
     outputSource:
       - subtract_lotss/regionbox
-    pickValue: all_non_null
+    pickValue: the_only_non_null
     doc: DS9 region file outside of which the LoTSS skymodel has been subtracted.
   - id: msout
     type: Directory[]

--- a/workflows/split-directions.cwl
+++ b/workflows/split-directions.cwl
@@ -215,7 +215,7 @@ outputs:
           items: File
       outputSource:
         - target_selfcal/images
-      pickValue: all_non_null
+      pickValue: the_only_non_null
     - id: phasediff_score_csv
       type: File?
       outputSource: phasediff_selection/phasediff_score_csv
@@ -225,4 +225,4 @@ outputs:
         - File[]
       outputSource:
         - target_selfcal/h5parm
-      pickValue: all_non_null
+      pickValue: the_only_non_null

--- a/workflows/subworkflows/concatenation.cwl
+++ b/workflows/subworkflows/concatenation.cwl
@@ -135,7 +135,7 @@ outputs:
   - id: aoflag_logfile
     outputSource:
         - concat_logfiles_aoflagging/output
-    pickValue: all_non_null
+    pickValue: the_only_non_null
     type: File
     doc: |
         The file containing the stdout and


### PR DESCRIPTION
Some sources used the all_non_null method to select objects which, according to the standard[1], is expected to return an array. In the case where only one object is supplied and expected to be passed on, this formally results type mismatch.

This did not appear to be a problem for PILoT previously as the object type was was itself an array, which is what cwltool seems to have tested against[2]. Since this was changed as of [3], we now need to be a bit more careful in selecting pickValue methods.

[1] https://www.commonwl.org/v1.2/Workflow.html#WorkflowStepInput
[2] https://github.com/common-workflow-language/cwltool/issues/2219
[3] https://github.com/common-workflow-language/cwltool/pull/2220