### PR TITLE
Update python requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "PILOT"
 description = "PILOT: the VLBI Pipeline for the International LOFAR Telescope"
 version = "0.9.1"
+requires-python = ">3.10"
 dependencies = [
     "astropy",
     "bdsf",
@@ -30,7 +31,7 @@ packages = []
 
 [tool.tox]
 requires = ["tox>=4.22"]
-envlist = ["py310", "py311", "py312", "py313"]
+envlist = ["py311", "py312", "py313"]
 
 [tool.tox.env_run_base]
 change_dir = "{tox_root}/tests"


### PR DESCRIPTION
PILoT requires Python 3.10 or newer, while lofar_vlbi_plot requires at least Python 3.11. Since [3.10 will reach its end-of-life](https://devguide.python.org/versions/) soon anyway we can drop support for it.