### PR TITLE
plot facet layout

### DIFF
--- a/scripts/plot_facet_layout.py
+++ b/scripts/plot_facet_layout.py
@@ -33,7 +33,7 @@ def get_phase_centre(ms: str) -> tuple[float, float]:
         Declination in degrees.
     """
     with table(f"{ms}::FIELD", ack=False) as t:
-        ra, dec = np.degrees(t.getcol("PHASE_DIR")).squeeze()
+        ra, dec = np.rad2deg(t.getcol("PHASE_DIR")).squeeze()
     return ra % 360, dec
 
 

--- a/scripts/plot_facet_layout.py
+++ b/scripts/plot_facet_layout.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+__author__ = "Jurjen de Jong"
+
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+from casacore.tables import table
+
+plt.rcParams.update({
+    "font.family": "Serif", "font.size": 18,
+    "axes.labelsize": 18, "axes.titlesize": 18,
+    "xtick.labelsize": 18, "ytick.labelsize": 18,
+    "legend.fontsize": 18, "legend.title_fontsize": 18
+})
+
+
+def get_phase_centre(ms: str) -> tuple[float, float]:
+    """
+    Get the phase centre of a MeasurementSet.
+
+    Parameters
+    ----------
+    ms : str
+        Path to the MeasurementSet.
+
+    Returns
+    -------
+    ra : float
+        Right ascension in degrees, wrapped to [0, 360).
+    dec : float
+        Declination in degrees.
+    """
+    with table(f"{ms}::FIELD", ack=False) as t:
+        ra, dec = np.degrees(t.getcol("PHASE_DIR")).squeeze()
+    return ra % 360, dec
+
+
+def parse_polygons(filepath: str) -> list[np.ndarray]:
+    """
+    Parse polygon regions from a DS9 region file.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to the DS9 .reg file.
+
+    Returns
+    -------
+    polygons : list of np.ndarray
+        Each element is an (N, 2) array of (RA, Dec) vertices in degrees.
+    """
+    polygons = []
+    with open(filepath) as f:
+        for line in f:
+            if line.strip().startswith('polygon'):
+                coords = np.array(line.strip()[8:-1].split(','), dtype=float).reshape(-1, 2)
+                polygons.append(coords)
+    return polygons
+
+
+def plot_ds9_regions(filepath: str, msfiles: list[str]) -> None:
+    """
+    Plot DS9 polygon regions and label each facet with its facet number.
+    Output image is saved as 'facet_layout.png'.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to the DS9 .reg file.
+    msfiles : list of str
+        Paths to MeasurementSets.
+    """
+    phase_centres = [get_phase_centre(ms) for ms in msfiles]
+    ras, decs = zip(*phase_centres)
+    fnums = [ms.split("_")[1] for ms in msfiles]
+
+    polygons = parse_polygons(filepath)
+
+    _, ax = plt.subplots(figsize=(12, 7))
+
+    for coords in polygons:
+        ax.add_patch(plt.Polygon(coords, closed=True, edgecolor='darkred', facecolor='none', linewidth=1.2))
+        centroid = coords.mean(axis=0)
+        closest = np.argmin([(ra - centroid[0])**2 + (dec - centroid[1])**2 for ra, dec in zip(ras, decs)])
+        ax.annotate(fnums[closest], centroid, fontsize=16, color='steelblue', ha='center', va='center')
+
+    ax.autoscale_view()
+    ax.set_xlabel('Right Ascension (deg)')
+    ax.set_ylabel('Declination (deg)')
+    ax.invert_xaxis()
+    plt.tight_layout()
+    plt.savefig('facet_layout.png', dpi=150)
+
+
+def main():
+    """Main function."""
+    parser = argparse.ArgumentParser(description='Plot DS9 region file with facet numbers.')
+    parser.add_argument('--facet_layout', help='Path to the DS9 .reg file', required=True)
+    parser.add_argument('--ms', nargs='+', help='MeasurementSets of polygons', required=True)
+    args = parser.parse_args()
+
+    plot_ds9_regions(args.facet_layout, args.ms)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/plot_facet_layout.py
+++ b/scripts/plot_facet_layout.py
@@ -109,7 +109,7 @@ def plot_ds9_regions(filepath: str, msfiles: list[str]) -> None:
     ax.set_ylabel('Declination (deg)')
     ax.invert_xaxis()
     plt.tight_layout()
-    plt.savefig(f'facet_layout_{obs_id}.png', dpi=150)
+    plt.savefig(f'facet_layout_L{obs_id}.png', dpi=150)
 
 
 def main():

--- a/scripts/plot_facet_layout.py
+++ b/scripts/plot_facet_layout.py
@@ -37,6 +37,23 @@ def get_phase_centre(ms: str) -> tuple[float, float]:
     return ra % 360, dec
 
 
+def get_obsid(ms):
+    """
+    Extract Observation ID from MeasurementSet metadata.
+    Parameters
+    ----------
+    ms : str
+        Path to the MeasurementSet.
+
+    Returns
+    -------
+    obsid : str
+        Observation ID.
+    """
+    with table(f"{ms}::OBSERVATION", ack=False) as t:
+        return t.getcol("LOFAR_OBSERVATION_ID")[0]
+
+
 def parse_polygons(filepath: str) -> list[np.ndarray]:
     """
     Parse polygon regions from a DS9 region file.
@@ -72,6 +89,7 @@ def plot_ds9_regions(filepath: str, msfiles: list[str]) -> None:
     msfiles : list of str
         Paths to MeasurementSets.
     """
+    obs_id = get_obsid(msfiles[0])
     phase_centres = [get_phase_centre(ms) for ms in msfiles]
     ras, decs = zip(*phase_centres)
     fnums = [ms.split("_")[1] for ms in msfiles]
@@ -91,7 +109,7 @@ def plot_ds9_regions(filepath: str, msfiles: list[str]) -> None:
     ax.set_ylabel('Declination (deg)')
     ax.invert_xaxis()
     plt.tight_layout()
-    plt.savefig('facet_layout.png', dpi=150)
+    plt.savefig(f'facet_layout_{obs_id}.png', dpi=150)
 
 
 def main():

--- a/steps/plot_facet_layout.cwl
+++ b/steps/plot_facet_layout.cwl
@@ -28,7 +28,7 @@ outputs:
     type: File
     doc: Facet layout PNG
     outputBinding:
-      glob: "facet_layout.png"
+      glob: "facet_layout*.png"
 
 hints:
   - class: DockerRequirement

--- a/steps/plot_facet_layout.cwl
+++ b/steps/plot_facet_layout.cwl
@@ -33,5 +33,3 @@ outputs:
 hints:
   - class: DockerRequirement
     dockerPull: vlbi-cwl
-  - class: ResourceRequirement
-    coresMin: 1

--- a/steps/plot_facet_layout.cwl
+++ b/steps/plot_facet_layout.cwl
@@ -1,0 +1,35 @@
+class: CommandLineTool
+cwlVersion: v1.2
+id: plot_facet_layout
+label: Plot facet layout
+doc: Plot facet layout with facet numbers obtained from MeasurementSet phase centres.
+
+baseCommand: plot_facet_layout.py
+
+inputs:
+  - id: msin
+    type: Directory[]
+    doc: MeasurementSets
+    inputBinding:
+      prefix: "--ms"
+      position: 0
+
+  - id: facet_layout
+    type: File
+    doc: DS9 polygon file
+    inputBinding:
+      prefix: "--facet_layout"
+      position: 1
+
+outputs:
+  - id: facet_layout_png
+    type: File
+    doc: Facet layout PNG
+    outputBinding:
+      glob: "facet_layout.png"
+
+hints:
+  - class: DockerRequirement
+    dockerPull: vlbi-cwl
+  - class: ResourceRequirement
+    coresMin: 1

--- a/steps/plot_facet_layout.cwl
+++ b/steps/plot_facet_layout.cwl
@@ -13,6 +13,7 @@ inputs:
     inputBinding:
       prefix: "--ms"
       position: 0
+      separate: true
 
   - id: facet_layout
     type: File
@@ -20,6 +21,7 @@ inputs:
     inputBinding:
       prefix: "--facet_layout"
       position: 1
+      separate: true
 
 outputs:
   - id: facet_layout_png

--- a/workflows/facet_subtract.cwl
+++ b/workflows/facet_subtract.cwl
@@ -123,6 +123,16 @@ steps:
       run: ../steps/dp3_parset.cwl
       scatter: parset
 
+    - id: plot_facet_layout
+      in:
+        - id: msin
+          source: concat_facets/msout
+        - id: facet_layout
+          source: get_facet_layout/facet_regions
+      out:
+        - id: facet_layout_png
+      run: ../steps/plot_facet_layout.cwl
+
 requirements:
   - class: MultipleInputFeatureRequirement
   - class: ScatterFeatureRequirement
@@ -138,3 +148,6 @@ outputs:
     - id: polygon_regions
       type: File[]
       outputSource: split_polygons/polygon_regions
+    - id: facet_layout_png
+      type: File
+      outputSource: plot_facet_layout/facet_layout_png


### PR DESCRIPTION
After facet-subtraction, it is useful to know which facet number corresponds to which facet. So, this MR adds a step that generates a facet layout inspection plot, such as the one below.

<img width="1170" height="663" alt="image" src="https://github.com/user-attachments/assets/d507dae1-1304-43e0-bf75-74898e0ddb6e" />
