### PR TITLE
fix bug for intermediate resolution imaging

### DIFF
--- a/workflows/image_intermediate_resolution.cwl
+++ b/workflows/image_intermediate_resolution.cwl
@@ -87,7 +87,7 @@ steps:
       in:
         - id: msin
           source: average_data/ms_avg
-        - id: ncpu
+        - id: cores
           source: number_cores
         - id: tmpdir
           source: tmpdir_wsclean


### PR DESCRIPTION
Fix bug that appears due to wrong parameter name in image_intermediate_resolution.cwl.