### PR TITLE
Rename cores to ncpu in wsclean

### DIFF
--- a/steps/wsclean.cwl
+++ b/steps/wsclean.cwl
@@ -24,7 +24,7 @@ inputs:
       shellQuote: false
       itemSeparator: ' '
       prefix: '-temp-dir'
-  - id: cores
+  - id: ncpu
     type: int?
     default: 24
     inputBinding:

--- a/workflows/subworkflows/image_and_trim.cwl
+++ b/workflows/subworkflows/image_and_trim.cwl
@@ -55,7 +55,7 @@ steps:
     - id: make_facet_image
       label: make_facet_image
       in:
-        - id: cores
+        - id: ncpu
           source: number_cores
         - id: msin
           source: msin


### PR DESCRIPTION
image_intermediate_resolution.cwl called wsclean with the `ncpu` input. wsclean.cwl does not have this input; it has `cores`. I expect that this got mixed up due to the discussion in #110[1].

I have renamed the wsclean.cwl input `ncpu` per the consensus of the earlier discussion.

[1] https://github.com/LOFAR-VLBI/pilot/pull/110#discussion_r3220650999