### PR TITLE
Skip missing interpreters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ packages = []
 [tool.tox]
 requires = ["tox>=4.22"]
 envlist = ["py311", "py312", "py313"]
+skip_missing_interpreters = true
 
 [tool.tox.env_run_base]
 change_dir = "{tox_root}/tests"


### PR DESCRIPTION
Our CI runs tox on all python versions. This causes the pipeline to fail as [recent versions of tox no longer skip missing interpreters](https://tox.wiki/en/latest/changelog.html#bug-fixes-4-56-0). I have added a flag to pyproject.toml to revert this.