### PR TITLE
Fix runtime errors facet imaging

### DIFF
--- a/steps/estimate_image_size.cwl
+++ b/steps/estimate_image_size.cwl
@@ -56,3 +56,7 @@ outputs:
 
 requirements:
     - class: InlineJavascriptRequirement
+
+hints:
+  - class: DockerRequirement
+    dockerPull: vlbi-cwl

--- a/steps/wsclean.cwl
+++ b/steps/wsclean.cwl
@@ -53,7 +53,7 @@ inputs:
       prefix: '-minuv-l'
   - id: weight
     type: string?
-    default: briggs -1.5
+    default: briggs -1.4
     inputBinding:
       position: 1
       shellQuote: false
@@ -193,7 +193,7 @@ inputs:
       prefix: '-join-channels'
   - id: fit-spectral-pol
     type: int?
-    default: 9
+    default: 5
     inputBinding:
       position: 1
       shellQuote: false

--- a/steps/wsclean.cwl
+++ b/steps/wsclean.cwl
@@ -255,7 +255,7 @@ inputs:
       prefix: '-dd-psf-grid'
   - id: scalar-visibilities
     type: boolean?
-    default: true
+    default: false
     inputBinding:
       position: 1
       shellQuote: false

--- a/steps/wsclean.cwl
+++ b/steps/wsclean.cwl
@@ -349,7 +349,7 @@ requirements:
     listing:
       - entry: $(inputs.msin)
   - class: ResourceRequirement
-    coresMin: $(inputs.cores)
+    coresMin: $(inputs.ncpu)
 
 stdout: wsclean.log
 stderr: wsclean_err.log

--- a/workflows/facet_imaging.cwl
+++ b/workflows/facet_imaging.cwl
@@ -102,7 +102,7 @@ steps:
       out:
         - id: output_image
       run: ../steps/swarp.cwl
-      when: $(config != null)
+      when: $(inputs.config != null)
 
 outputs:
   - id: MFS_images_pb

--- a/workflows/facet_imaging.cwl
+++ b/workflows/facet_imaging.cwl
@@ -41,6 +41,9 @@ inputs:
         If mosaic is true, a final mosaic will be made of the trimmed facet images
         using this configuration.
 
+    - id: tmpdir
+      type: string?
+      doc: Temporary directory to run I/O heavy jobs.
 
 steps:
     - id: sort_mses
@@ -72,6 +75,8 @@ steps:
           source: pixel_scale
         - id: resolution
           source: resolution
+        - id: tmpdir
+          source: tmpdir
       out:
         - id: MFS_image_pb
         - id: MFS_image

--- a/workflows/facet_imaging.cwl
+++ b/workflows/facet_imaging.cwl
@@ -9,6 +9,7 @@ doc: |
 requirements:
     - class: ScatterFeatureRequirement
     - class: SubworkflowFeatureRequirement
+    - class: InlineJavascriptRequirement
 
 inputs:
     - id: msin

--- a/workflows/image_intermediate_resolution.cwl
+++ b/workflows/image_intermediate_resolution.cwl
@@ -112,6 +112,8 @@ steps:
               "facet-solutions": inputs.dd_solutions,
               "soltabs": ["amplitude000", "phase000"]
             })
+        - id: scalar-visibilities
+          default: true
       out:
         - id: MFS_image_pb
         - id: MFS_image

--- a/workflows/subworkflows/image_and_trim.cwl
+++ b/workflows/subworkflows/image_and_trim.cwl
@@ -82,6 +82,8 @@ steps:
           default: false
         - id: apply-primary-beam
           default: true
+        - id: scalar-visibilities
+          default: false
       out:
         - id: MFS_image_pb
         - id: MFS_image

--- a/workflows/subworkflows/image_and_trim.cwl
+++ b/workflows/subworkflows/image_and_trim.cwl
@@ -36,6 +36,10 @@ inputs:
       doc: |
         Restoring beam to use for every facet following the WSClean order of major axis, minor axis, position angle.
 
+    - id: tmpdir
+      type: string?
+      doc: Temporary directory to run I/O heavy jobs.
+
 steps:
     - id: find_image_size
       label: image_size
@@ -72,6 +76,12 @@ steps:
           valueFrom: $(self.toString() + "asec")
         - id: beam-shape
           source: restoring_beam
+        - id: tmpdir
+          source: tmpdir
+        - id: apply-facet-beam
+          default: false
+        - id: apply-primary-beam
+          default: true
       out:
         - id: MFS_image_pb
         - id: MFS_image

--- a/workflows/subworkflows/image_and_trim.cwl
+++ b/workflows/subworkflows/image_and_trim.cwl
@@ -82,8 +82,6 @@ steps:
           default: false
         - id: apply-primary-beam
           default: true
-        - id: scalar-visibilities
-          default: false
       out:
         - id: MFS_image_pb
         - id: MFS_image


### PR DESCRIPTION
This MR fixes a few runtime error with the facet_imaging workflow:
* Missing `DockerRequirement`,
* incorrect input binding in workflow files,
* incorrect parameter reference in `ResourceRequirements`,
* changed default value of the WSClean `scalar-visibilities` input. 

It also improves imaging parameters and tmpdir paths based on tests with ELAIS-N1 and EDFN data.