### PR TITLE
Trim model images

### DIFF
--- a/scripts/filter_files_to_mses.py
+++ b/scripts/filter_files_to_mses.py
@@ -9,7 +9,11 @@ from submods.source_selection.selfcal_selection import parse_source_from_h5
 
 def main():
     parser = ArgumentParser(
-        description="Filters a given set of files into one that matches the set of MSes. This is done by extracting the source name, so both MSes and files are expected to follow the ILTJ... naming convention."
+        description=(
+            "Filters a given set of files into one that matches the set of MSes."
+            " This is done by extracting the source name, so both MSes and files"
+            " are expected to follow the ILTJ... naming convention."
+        )
     )
     parser.add_argument(
         "--ms",

--- a/scripts/filter_files_to_mses.py
+++ b/scripts/filter_files_to_mses.py
@@ -20,10 +20,14 @@ def main():
     parser.add_argument(
         "--files",
         type=str,
-        nargs="+",
+        nargs="*",
         help="Files to filter a set matching the MSes from.",
     )
     args = parser.parse_args()
+
+    if not args.files:
+        with open("cwl.output.json", "w") as f:
+            json.dump({"files": None}, f)
 
     source_names_ms = {parse_source_from_h5(ms) for ms in args.ms}
 
@@ -32,7 +36,8 @@ def main():
     cwl_files = [{"type": "Directory", "path": f} for f in keep_files]
 
     with open("cwl.output.json", "w") as f:
-        json.dump({"files": cwl_files}, f)
+        if cwl_files:
+            json.dump({"files": cwl_files}, f)
 
 
 if __name__ == "__main__":

--- a/scripts/filter_files_to_mses.py
+++ b/scripts/filter_files_to_mses.py
@@ -33,7 +33,7 @@ def main():
 
     keep_files = [f for f in args.files if parse_source_from_h5(f) in source_names_ms]
 
-    cwl_files = [{"type": "Directory", "path": f} for f in keep_files]
+    cwl_files = [{"class": "File", "path": f} for f in keep_files]
 
     with open("cwl.output.json", "w") as f:
         if cwl_files:

--- a/scripts/filter_files_to_mses.py
+++ b/scripts/filter_files_to_mses.py
@@ -34,6 +34,13 @@ def main():
 
     keep_files = [f for f in args.files if parse_source_from_h5(f) in source_names_ms]
 
+    if not keep_files:
+        raise RuntimeError("No files in common with the MSes. Please check inputs.")
+    elif len(keep_files) != len(source_names_ms):
+        raise NotImplementedError(
+            "Number of files does not match number of MSes. This is not supported."
+        )
+
     cwl_files = [{"class": "File", "path": f} for f in keep_files]
 
     with open("cwl.output.json", "w") as f:

--- a/scripts/filter_files_to_mses.py
+++ b/scripts/filter_files_to_mses.py
@@ -44,8 +44,7 @@ def main():
     cwl_files = [{"class": "File", "path": f} for f in keep_files]
 
     with open("cwl.output.json", "w") as f:
-        if cwl_files:
-            json.dump({"filtered_files": cwl_files}, f)
+        json.dump({"filtered_files": cwl_files}, f)
 
 
 if __name__ == "__main__":

--- a/scripts/filter_files_to_mses.py
+++ b/scripts/filter_files_to_mses.py
@@ -28,6 +28,7 @@ def main():
     if not args.files:
         with open("cwl.output.json", "w") as f:
             json.dump({"filtered_files": None}, f)
+        return
 
     source_names_ms = {parse_source_from_h5(ms) for ms in args.ms}
 

--- a/scripts/filter_files_to_mses.py
+++ b/scripts/filter_files_to_mses.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+from argparse import ArgumentParser
+
+from submods.source_selection.selfcal_selection import parse_source_from_h5
+
+
+def main():
+    parser = ArgumentParser(
+        description="Filters a given set of files into one that matches the set of MSes. This is done by extracting the source name, so both MSes and files are expected to follow the ILTJ... naming convention."
+    )
+    parser.add_argument(
+        "--ms",
+        type=str,
+        nargs="+",
+        help="MSes to use as reference for filtering the files.",
+    )
+    parser.add_argument(
+        "--files",
+        type=str,
+        nargs="+",
+        help="Files to filter a set matching the MSes from.",
+    )
+    args = parser.parse_args()
+
+    source_names_ms = {parse_source_from_h5(ms) for ms in args.ms}
+
+    keep_files = [f for f in args.files if parse_source_from_h5(f) in source_names_ms]
+
+    cwl_files = [{"type": "Directory", "path": f} for f in keep_files]
+
+    with open("cwl.output.json", "w") as f:
+        json.dump({"files": cwl_files}, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/filter_files_to_mses.py
+++ b/scripts/filter_files_to_mses.py
@@ -27,7 +27,7 @@ def main():
 
     if not args.files:
         with open("cwl.output.json", "w") as f:
-            json.dump({"files": None}, f)
+            json.dump({"filtered_files": None}, f)
 
     source_names_ms = {parse_source_from_h5(ms) for ms in args.ms}
 
@@ -37,7 +37,7 @@ def main():
 
     with open("cwl.output.json", "w") as f:
         if cwl_files:
-            json.dump({"files": cwl_files}, f)
+            json.dump({"filtered_files": cwl_files}, f)
 
 
 if __name__ == "__main__":

--- a/steps/match_files_to_ms.cwl
+++ b/steps/match_files_to_ms.cwl
@@ -30,3 +30,6 @@ outputs:
   filtered_files:
     type:
       - File[]?
+
+stdout: match_files_to_ms.log
+stderr: match_files_to_ms_err.log

--- a/steps/match_files_to_ms.cwl
+++ b/steps/match_files_to_ms.cwl
@@ -30,6 +30,3 @@ outputs:
   filtered_files:
     type:
       - File[]?
-
-requirements:
-  - class: InlineJavascriptRequirement

--- a/steps/match_files_to_ms.cwl
+++ b/steps/match_files_to_ms.cwl
@@ -19,7 +19,7 @@ inputs:
       separate: true
   files:
     type:
-      - File[]
+      - File[]?
     doc: Files to filter into a set that matches the MSes.
     inputBinding:
       prefix: "--files"
@@ -29,7 +29,7 @@ inputs:
 outputs:
   filtered_files:
     type:
-      - File[]
+      - File[]?
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/steps/match_files_to_ms.cwl
+++ b/steps/match_files_to_ms.cwl
@@ -1,0 +1,35 @@
+cwlVersion: v1.2
+class: CommandLineTool
+label: Match files and MSes by name.
+doc: |
+  Filters the input files to retain only those for which a corresponding MS
+  exists. This is checked by extracting the source name from both the file and
+  the MS.
+
+baseCommand: filter_files_to_mses.py
+
+inputs:
+  ms:
+    type:
+      - Directory[]
+    doc: Input MeasurementSets to filter with
+    inputBinding:
+      prefix: "--ms"
+      position: 1
+      separate: true
+  files:
+    type:
+      - File[]
+    doc: Files to filter into a set that matches the MSes.
+    inputBinding:
+      prefix: "--files"
+      position: 2
+      separate: true
+
+outputs:
+  filtered_files:
+    type:
+      - File[]
+
+requirements:
+  - class: InlineJavascriptRequirement

--- a/workflows/subworkflows/find-best-delay-calibrator.cwl
+++ b/workflows/subworkflows/find-best-delay-calibrator.cwl
@@ -64,12 +64,23 @@ steps:
         - id: phasediff_score_csv
       run: ../split-directions.cwl
       label: select_best_delay_cal
+    
+    - id: filter_skymodels
+      in:
+        - id: ms
+          source: select_best_delay_cal/msout_concat
+        - id: files
+          source: starting_skymodel
+      out:
+        - id: filtered_files
+      run: ../../steps/match_files_to_ms.cwl
+      when: $(inputs.files != null)
 
     - id: sort_skymodels
       in:
         - id: input_entry
           source:
-            - starting_skymodel
+            - filter_skymodels/filtered_files
           pickValue: all_non_null
           linkMerge: merge_flattened
       out:


### PR DESCRIPTION
Fixes #138 

A selection of delay calibrator candidates can be made based on the phasediff score, but the corresponding array of starting model images is not yet trimmed to this same amount. This causes a crash in case the number of candidates to select doesn't match the number of input model images.

This PR adds an extra step before in the self calibration to ensure there is an equal number of model images.