### PR TITLE
Add memory requirement to auto selfcal

### DIFF
--- a/steps/facet_selfcal_auto.cwl
+++ b/steps/facet_selfcal_auto.cwl
@@ -91,6 +91,7 @@ hints:
     dockerPull: vlbi-cwl
   - class: ResourceRequirement
     coresMin: 12
+    ramMin: 32000
 
 stdout: facet_selfcal.log
 stderr: facet_selfcal_err.log


### PR DESCRIPTION
My dd-calibration run on cosma kept getting OoM-killed on the selfcal. This step currently doesn't have a `ramMin` set (the normal one for the delay cal does). A quick look at Toil's stats lands at around 26 GB:

```
  CWLJob auto_selfcal.run_facetselfcal.facet_selfcal_international
     Total Cores: 60.0
     Count |                                Real Time* |                              CPU Time (core) |                               CPU Wait (core) |                               Memory (B) |                                 Disk (B) 
         n |      min    med*     ave     max    total |      min      med     ave      max     total |      min     med     ave     max        total |      min     med     ave     max   total |      min     med     ave     max   total 
         5 |    5m59s  18m52s  18m17s  32m41s   91m28s |   36m50s 2h33m31s 2h30m9s 4h48m15s 12h30m47s |    35m7s   73m3s  69m21s 103m58s     5h46m48s |    3.4Gi   6.4Gi   5.3Gi   6.8Gi  26.6Gi |      4Ki     4Ki     4Ki     4Ki    20Ki
```

To have some leeway this PR makes the minimum reserved RAM 32 GB.