### PR TITLE
Reserve memory for DD calibration h5merge

### DIFF
--- a/steps/multidir_merger.cwl
+++ b/steps/multidir_merger.cwl
@@ -36,6 +36,8 @@ requirements:
 hints:
   - class: DockerRequirement
     dockerPull: vlbi-cwl
+  - class: ResourceRequirement
+    ramMin: 45000
 
 stdout: multidir_h5_merger.log
 stderr: multidir_h5_merger_err.log


### PR DESCRIPTION
This PR adds a memory allocation to the merging of all DD solutions. For my run Toil reports 21.61 GB used, but Slurm reports a max RSS of 44017964K, so I went with the Slurm value to be on the safe side as I don't know what Toil's polling frequency is. This is with 37 directions.