### PR TITLE
Return config files used for the DD selfcal as workflow outputs

### DIFF
--- a/workflows/dd-calibration.cwl
+++ b/workflows/dd-calibration.cwl
@@ -115,6 +115,7 @@ steps:
         - selfcal_images
         - selfcal_inspection_images
         - solution_inspection_images
+        - config_files
       run: ./subworkflows/ddcal_calibrators.cwl
 
     - id: validation
@@ -188,6 +189,11 @@ outputs:
       type: File[]
       outputSource: ddcal_int/selfcal_inspection_images
       doc: Self-calibration images in PNG format
+
+    - id: selfcal_configs
+      type: File[]
+      outputSource: ddcal_int/config_files
+      doc: Configuration files used by facetselfcal.
 
     - id: msout
       type: Directory[]

--- a/workflows/dd-calibration.cwl
+++ b/workflows/dd-calibration.cwl
@@ -118,6 +118,17 @@ steps:
         - config_files
       run: ./subworkflows/ddcal_calibrators.cwl
 
+    - id: store_configs
+      label: Store selfcal config files
+      in:
+        - id: files
+          source: ddcal_int/config_files
+        - id: sub_directory_name
+          default: selfcal_configs
+      out:
+        - id: dir
+      run: ../steps/collectfiles.cwl
+
     - id: validation
       in:
         - id: images
@@ -191,8 +202,8 @@ outputs:
       doc: Self-calibration images in PNG format
 
     - id: selfcal_configs
-      type: File[]
-      outputSource: ddcal_int/config_files
+      type: Directory
+      outputSource: store_configs/dir
       doc: Configuration files used by facetselfcal.
 
     - id: msout


### PR DESCRIPTION
This PR adds the facetselfcal config files as `dd-calibration` workflow outputs. Having these is useful for providing a starting point if manual calibration of a particular source is desirable and also for rerunning sources (which could be useful to get all of the images for expanding the training set of the NN, for example)