### PR TITLE
Fix glob for MFS psf in wsclean step

### DIFF
--- a/steps/wsclean.cwl
+++ b/steps/wsclean.cwl
@@ -332,7 +332,7 @@ outputs:
     type: File
     doc: The final primary beam corrected image.
     outputBinding:
-      glob: '$(inputs.name)-MFS-psf.fits'
+      glob: '$(inputs.name)*-MFS-psf.fits'
   - id: channel_model_images
     type: File[]
     doc: Per-channel model images required for the facet subtraction.

--- a/steps/wsclean.cwl
+++ b/steps/wsclean.cwl
@@ -329,7 +329,9 @@ outputs:
     outputBinding:
       glob: '$(inputs.name)-MFS-model.fits'
   - id: MFS_psf
-    type: File
+    type:
+      - File
+      - File[]
     doc: The final primary beam corrected image.
     outputBinding:
       glob: '$(inputs.name)*-MFS-psf.fits'

--- a/steps/wsclean.cwl
+++ b/steps/wsclean.cwl
@@ -332,7 +332,7 @@ outputs:
     type:
       - File
       - File[]
-    doc: The final primary beam corrected image.
+    doc: The MFS psf image, or images per psf direction if a direction-dependent psf is used.
     outputBinding:
       glob: '$(inputs.name)*-MFS-psf.fits'
   - id: channel_model_images

--- a/workflows/image_intermediate_resolution.cwl
+++ b/workflows/image_intermediate_resolution.cwl
@@ -179,7 +179,9 @@ outputs:
 
     - id: MFS_psf
       outputSource: make_intermediate_resolution_image/MFS_psf
-      type: File
+      type:
+        - File
+        - File[]
       doc: |
         Final MFS psf FITS image at intermediate resolution.
     - id: channel_model_images


### PR DESCRIPTION
In normal imaging runs the MFS psf is named `<image_name>-MFS-psf.fits`, but when direction-dependent psfs are used you get one for each psf direction via `<image_name>-d????-MFS-psf.fits`. This caused the intermediate-resolution imaging to crash for me.

This PR adjusts the glob slightly to account for both.