### PR TITLE
Write image name with quotes in dical config

### DIFF
--- a/scripts/make_config_dical.py
+++ b/scripts/make_config_dical.py
@@ -144,7 +144,9 @@ def write_config(filename: str, configdict: dict[str, object]) -> str:
             ## string, int, float, or array
             value = configdict[key]
             match value:
-              case str() | int() | float():
+              case str():
+                f.write(f'{key} = "{value}"\n')
+              case int() | float():
                 f.write(f'{key} = {value}\n')
               case Sequence():
                 ss = []


### PR DESCRIPTION
In #140 the image name is written unquoted (never assume a straightforwad update won't break anything I guess haha), causing facetselfcal to crash. This PR updates the matching such that strings are written with quotes, which should fix that issue.