### PR TITLE
Make applycal naming more flexible

### DIFF
--- a/steps/applycal.cwl
+++ b/steps/applycal.cwl
@@ -20,13 +20,17 @@ inputs:
         prefix: "--h5"
         position: 4
         separate: true
+    - id: infix
+      type: string?
+      doc: Text to add to the MS name before the final suffix.
+      default: ".applied"
 
 outputs:
     - id: ms_out
       type: Directory
       doc: Output MeasurementSet with solutions applied
       outputBinding:
-        glob: "applied_*"
+        glob: "*$(inputs.infix)*"
     - id: logfile
       type: File[]
       doc: Log files corresponding to this step
@@ -41,7 +45,11 @@ requirements:
       - entry: $(inputs.h5parm)
 
 arguments:
-  - --msout=$( 'applied_' + inputs.ms.basename )
+  - --msout=${
+      var base = inputs.ms.basename;
+      var i = base.lastIndexOf(".");
+      return base.slice(0, inputs.ms.basename.lastIndexOf(".")) + inputs.infix + base.slice(i);
+    }
 
 hints:
   - class: DockerRequirement

--- a/steps/applycal.cwl
+++ b/steps/applycal.cwl
@@ -48,7 +48,7 @@ arguments:
   - --msout=${
       var base = inputs.ms.basename;
       var i = base.lastIndexOf(".");
-      return base.slice(0, inputs.ms.basename.lastIndexOf(".")) + inputs.infix + base.slice(i);
+      return base.slice(0, i) + inputs.infix + base.slice(i);
     }
 
 hints:

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -264,6 +264,8 @@ steps:
           # clause for this step prevents from running if we have more than 1 candidate, so
           # we should never be in a situation of having File[] here.
           valueFrom: $(self)
+        - id: infix
+          default: ".delay_corrected"
         - id: apply_delay_solutions
           source: apply_delay_solutions
         - id: select_best_n_delay_calibrators

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -350,5 +350,5 @@ outputs:
     outputSource:
       - phaseup/summary_file
     pickValue: all_non_null
-    type: File[]
+    type: File
     doc: Pipeline summary statistics in JSON format.

--- a/workflows/delay-calibration.cwl
+++ b/workflows/delay-calibration.cwl
@@ -351,6 +351,5 @@ outputs:
   - id: summary_files
     outputSource:
       - phaseup/summary_file
-    pickValue: all_non_null
     type: File
     doc: Pipeline summary statistics in JSON format.


### PR DESCRIPTION
This PR changes the `applycal` step from hardcoding an `applied_` pattern to taking a flexible infix to append as second-to-last extension, i.e. `mydata.ms` -> `mydata<infix>.ms`. This makes the step more flexible and also more consistent with our general naming scheme of `L123456....` for measurement sets. 

It also:
- fixes a validation warning for the summary file of the delay-calibration workflow about `File` going into `File[]`
- changes the delay corrected output from `applied_L123...` to `L<bla>.delay_corrected.<original suffix>`