### PR TITLE
Add shared facet reads and writes to WSClean

### DIFF
--- a/steps/wsclean.cwl
+++ b/steps/wsclean.cwl
@@ -5,7 +5,7 @@ label: WSClean
 doc: Runs WSClean on the input data to produce an image.
 
 baseCommand: wsclean
-arguments: [-verbose, -log-time, -no-update-model-required, -reorder]
+arguments: [-verbose, -log-time, -no-update-model-required, -reorder, -shared-facet-reads, -shared-facet-writes]
 
 inputs:
   - id: msin


### PR DESCRIPTION
This adds the `-shared-facet-reads` and `-shared-facet-writes` to the WSClean call. This is useful for the initial intermediate resolution imaging step where it provides a speed-up. Below is a comparison of a run on LockmanB with 46 directions. In scenarios like this it should reduce the cost and time by about 10%.

**Without shared reads/writes**
```
8405:2026-Aug-16 12:06:54.706883  == Deconvolving (1) ==
18826:2026-Aug-16 20:04:25.039212  == Deconvolving (2) ==
29135:2026-Aug-17 04:00:24.867379  == Deconvolving (3) ==
39482:2026-Aug-17 11:58:37.866484  == Deconvolving (4) ==
49800:2026-Aug-17 19:33:54.081179  == Deconvolving (5) ==
60267:2026-Aug-18 02:57:57.221698  == Deconvolving (6) ==
70730:2026-Aug-18 10:29:09.483278  == Deconvolving (7) ==
80772:2026-Aug-18 17:42:37.926212  == Deconvolving (8) ==
```
Roughly 7.5-8 hours per cycle.

**With shared reads/writes**
```
7287:2026-Aug-20 02:36:30.386506  == Deconvolving (1) ==
18903:2026-Aug-20 09:21:24.813527  == Deconvolving (2) ==
30440:2026-Aug-20 16:21:15.697285  == Deconvolving (3) ==
42033:2026-Aug-20 23:02:48.272636  == Deconvolving (4) ==
53565:2026-Aug-21 05:28:54.623956  == Deconvolving (5) ==
65270:2026-Aug-21 12:01:02.542855  == Deconvolving (6) ==
```
Roughly 6.5-7 hours per cycle.